### PR TITLE
Bumping requirements up to 2.0.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     },
     "require": {
         "php": ">=5.5.9",
-        "pattern-lab/patternengine-twig": "0.*"
+        "pattern-lab/patternengine-twig": "^2.0.0"
     }
 }


### PR DESCRIPTION
While bumping the requirements up on [PL Drupal Edition](https://github.com/pattern-lab/edition-php-drupal-standard), this came up as a needed change. Mind pushing this out and tagging a new release for us? I went to `v2.0.0` on https://github.com/pattern-lab/plugin-drupal-twig-components , perhaps that's a good new version for yours too?
