### PR TITLE
Let plugins twig extensions to load nicely

### DIFF
--- a/src/aleksip/DataTransformPlugin/PatternLabListener.php
+++ b/src/aleksip/DataTransformPlugin/PatternLabListener.php
@@ -22,7 +22,7 @@ class PatternLabListener extends Listener
     public function __construct()
     {
         $this->addListener('patternData.codeHelperStart', 'dataTransformer');
-        $this->addListener('twigPatternLoader.customize', 'addNodeVisitor');
+        $this->addListener('twigPatternLoader.customize', 'addNodeVisitor', -99);
         if ($this->isVerbose()) {
             Console::writeLine('data transform plugin listeners added...');
         }


### PR DESCRIPTION
Set addNodeVisitor to a lower priority, so other plugins can CRUD twig extensions.

This PR tries to fix #24 , by setting -99 priority for the  `twigPatternLoader.customize` event subscriber. In fact when `addNodeVisitor` runs, Twig is initialised and new extensions can be registered. By setting this to -99 (default priority is 0) all plugins subscribers will run before us.