### PR TITLE
Avoid "Undefined index" PHP Notice

### DIFF
--- a/src/aleksip/DataTransformPlugin/DataTransformer.php
+++ b/src/aleksip/DataTransformPlugin/DataTransformer.php
@@ -79,7 +79,7 @@ class DataTransformer
             foreach (array_keys($patternSpecificData) as $key) {
               if (!isset($dataStore['patternSpecific'][$pattern]['data'][$key])) {
                 // Value is default global data.
-                if (is_object($dataStore[$key])) {
+                if (isset($dataStore[$key]) && is_object($dataStore[$key])) {
                   $patternSpecificData[$key] = clone $dataStore[$key];
                 }
               }


### PR DESCRIPTION
Controls if element `$dataStore[$key]` exists, before checking if it's an object.

This should fix #23 .